### PR TITLE
fix(ewars): do not extract closed_date

### DIFF
--- a/dhis2_ewars_push/pipeline.py
+++ b/dhis2_ewars_push/pipeline.py
@@ -9,12 +9,11 @@ import requests
 
 from openhexa.sdk import pipeline, workspace, current_run, parameter
 from openhexa.toolbox.dhis2 import DHIS2
-from openhexa.toolbox.dhis2.dataframe import get_organisation_units
 
 import config
 from ewars_client import EWARSClient
 
-from utils import split_list, get_response_value_errors
+from utils import split_list, get_response_value_errors, get_organisation_units
 
 
 @pipeline("dhis2-ewars-push")

--- a/dhis2_ewars_push/utils.py
+++ b/dhis2_ewars_push/utils.py
@@ -1,4 +1,9 @@
 from collections.abc import Iterator
+import polars as pl
+
+from openhexa.sdk import current_run
+from openhexa.toolbox.dhis2.dataframe import get_organisation_unit_levels, InvalidParameterError
+from openhexa.toolbox.dhis2 import DHIS2
 
 
 def split_list(src_list: list, length: int) -> Iterator[list]:
@@ -45,3 +50,81 @@ def get_response_value_errors(response, chunk) -> dict:
         return out
     except AttributeError:
         return None
+
+
+def get_organisation_units(
+    dhis2: DHIS2, max_level: int | None = None, filters: list[str] | None = None
+) -> pl.DataFrame:
+    """Extract organisation units metadata.
+
+    Parameters
+    ----------
+    dhis2 : DHIS2
+        DHIS2 instance.
+    max_level : int, optional
+        Maximum level of organisation units to extract. If None, all levels are extracted.
+    filters : list[str], optional
+        DHIS2 query filter expressions.
+
+    Returns
+    -------
+    pl.DataFrame
+        Dataframe containing organisation units metadata with the following columns: id, name,
+        level, level_{level}_id, level_{level}_name, geometry.
+
+    Raises
+    ------
+    InvalidParameter
+        If max_level is greater than the maximum level of the organisation units.
+    """
+    levels = get_organisation_unit_levels(dhis2)
+    if max_level:
+        if max_level > levels["level"].max():
+            msg = f"max_level cannot be greater than {levels['level'].max()}"
+            current_run.log_error(msg)
+            raise InvalidParameterError(msg)
+        level_filter = f"level:le:{max_level}"
+        if filters:
+            filters = [*filters, max_level]
+        else:
+            filters = [level_filter]
+
+    meta = dhis2.meta.organisation_units(fields="id,name,level,path,openingDate,geometry", filters=filters)
+
+    schema = {
+        "id": str,
+        "name": str,
+        "level": int,
+        "path": str,
+        "openingDate": str,
+        "geometry": str,
+    }
+    df = pl.DataFrame(data=meta, schema=schema)
+
+    for row in levels.iter_rows(named=True):
+        lvl = row["level"]
+        if max_level:
+            if lvl > max_level:
+                continue
+
+        df = df.with_columns(
+            pl.col("path").str.split("/").list.slice(1).list.get(lvl - 1, null_on_oob=True).alias(f"level_{lvl}_id")
+        )
+
+        df = df.join(
+            other=df.select("id", pl.col("name").alias(f"level_{lvl}_name")),
+            left_on=f"level_{lvl}_id",
+            right_on="id",
+            how="left",
+        )
+
+    df = df.select(
+        "id",
+        "name",
+        "level",
+        pl.col("openingDate").str.to_datetime("%Y-%m-%dT%H:%M:%S.%3f").alias("opening_date"),
+        *[col for col in df.columns if col.startswith("level_")],
+        "geometry",
+    )
+
+    return df.sort(by=["level", "name"], descending=False)


### PR DESCRIPTION
In this pipeline, we extract the DHIS2 pyramid. Before, we were doing it with the get_organisation_units function from the toolbox; that extracts the pyramid and cleans it. One of the things that it does is extract the closedDate column; and demand that all of it can be converted to a date. In this case, there was a weird value in DHIS2's pyramid in the closedDate column. This caused the pipeline to fail: 
https://app.openhexa.org/workspaces/drc-pnlp-ccd423/pipelines/dhis2-ewars-push/runs/a1a30d3b-0ffb-4f09-abed-7682cd2324c5/
Since we do not need this column for anything, simply copy the function from the toolbox into the code, and stop the extraction of the closedDate column. Now it works: https://app.openhexa.org/workspaces/drc-pnlp-ccd423/pipelines/dhis2-ewars-push/runs/66ee6366-32cc-4b86-985c-652458def291/